### PR TITLE
Guard haptics for iOS and localize achievement model

### DIFF
--- a/Grow/Managers/AchievementManager.swift
+++ b/Grow/Managers/AchievementManager.swift
@@ -1,11 +1,24 @@
 import CoreData
 import Foundation
 
+struct UnlockedAchievement: Identifiable {
+    let id: String
+    let key: String
+    let name: String
+    let description: String
+    let icon: String
+    let earnedAt: Date?
+    let progress: Int
+    let target: Int
+
+    var isUnlocked: Bool { progress >= target }
+}
+
 class AchievementManager {
     static let shared = AchievementManager()
-    
-    func checkAchievements(gameManager: GameManager) -> [Achievement] {
-        var unlocked: [Achievement] = []
+
+    func checkAchievements(gameManager: GameManager) -> [UnlockedAchievement] {
+        var unlocked: [UnlockedAchievement] = []
         guard let profile = gameManager.profile else { return [] }
         
         let achievements = [
@@ -41,7 +54,7 @@ class AchievementManager {
             
             if shouldUnlock {
                 UserDefaults.standard.set(true, forKey: userDefaultKey)
-                let achievement = Achievement(
+                let achievement = UnlockedAchievement(
                     id: key,
                     key: key,
                     name: name,

--- a/Grow/Managers/GameManager.swift
+++ b/Grow/Managers/GameManager.swift
@@ -1,5 +1,9 @@
 import SwiftUI
+import Combine
 import CoreData
+#if os(iOS)
+import UIKit
+#endif
 
 class GameManager: ObservableObject {
     let context: NSManagedObjectContext
@@ -15,10 +19,16 @@ class GameManager: ObservableObject {
     @Published var showAchievementModal = false
     @Published var showUndoSnackbar = false
     @Published var lastAction: (() -> Void)?
-    @Published var lastAchievement: Achievement?
+    @Published var lastAchievement: UnlockedAchievement?
     @Published var skillPoints = 0
     @Published var ironWillUsesThisWeek = 0
-    
+
+    private enum HapticEvent {
+        case success
+        case warning
+        case error
+    }
+
     init(context: NSManagedObjectContext) {
         self.context = context
         loadData()
@@ -276,8 +286,23 @@ class GameManager: ObservableObject {
         }
     }
     
-    private func triggerHaptic(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+    private func triggerHaptic(_ event: HapticEvent) {
+#if os(iOS)
         let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(type)
+        let feedbackType: UINotificationFeedbackGenerator.FeedbackType
+
+        switch event {
+        case .success:
+            feedbackType = .success
+        case .warning:
+            feedbackType = .warning
+        case .error:
+            feedbackType = .error
+        }
+
+        generator.notificationOccurred(feedbackType)
+#else
+        _ = event
+#endif
     }
 }

--- a/Grow/Models/Models.swift
+++ b/Grow/Models/Models.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import CoreData
+import Foundation
 
 enum HabitType: String, Codable, CaseIterable {
     case daily, weekly
@@ -42,7 +43,7 @@ enum SkillKey: String, Codable, CaseIterable {
     case nightOwl = "night_owl"
     case perfectionist = "perfectionist"
     case resilient = "resilient"
-    
+
     var name: String {
         switch self {
         case .earlyBird: return "Early Bird"
@@ -53,7 +54,7 @@ enum SkillKey: String, Codable, CaseIterable {
         case .resilient: return "Resilient"
         }
     }
-    
+
     var description: String {
         switch self {
         case .earlyBird: return "+10% EXP before 10am"
@@ -64,14 +65,16 @@ enum SkillKey: String, Codable, CaseIterable {
         case .resilient: return "Streak shield recharges faster"
         }
     }
-    
+
     var tier: Int {
         switch self {
-        case .earlyBird, .specialist, .ironWill: return 1
-        case .nightOwl, .perfectionist, .resilient: return 2
+        case .earlyBird, .specialist, .ironWill:
+            return 1
+        case .nightOwl, .perfectionist, .resilient:
+            return 2
         }
     }
-    
+
     var icon: String {
         switch self {
         case .earlyBird: return "sunrise.fill"
@@ -95,18 +98,6 @@ struct LeaderboardEntry: Codable, Identifiable {
     let bestStreak: Int
     let updatedAt: Date
     var rank: Int = 0
-}
-
-struct Achievement: Codable, Identifiable {
-    let id: String
-    let key: String
-    let name: String
-    let description: String
-    let icon: String
-    let earnedAt: Date?
-    let progress: Int
-    let target: Int
-    var isUnlocked: Bool { progress >= target }
 }
 
 extension UserProfile: Identifiable {}


### PR DESCRIPTION
## Summary
- introduce an UnlockedAchievement value local to AchievementManager so managers no longer depend on a shared Achievement model file
- update GameManager to publish the new UnlockedAchievement type and keep the achievement modal logic working
- restrict the UIKit import and haptic feedback helper to iOS builds so other platforms compile cleanly

## Testing
- not run (iOS project environment)


------
https://chatgpt.com/codex/tasks/task_e_68e592df23c8832ab4d8097666e91b7f