### PR TITLE
Fix missing model and onboarding sources in target

### DIFF
--- a/Grow.xcodeproj/project.pbxproj
+++ b/Grow.xcodeproj/project.pbxproj
@@ -39,9 +39,7 @@
 		74D238402E95AB1500527E63 /* Exceptions for "Grow" folder in "Grow" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				Info.plist,
-				Models/Models.swift,
-				Views/OnboardingView.swift,
+                                Info.plist,
 			);
 			target = 74D238192E95AB1400527E63 /* Grow */;
 		};


### PR DESCRIPTION
## Summary
- ensure `Models.swift` and `OnboardingView.swift` are included in the Grow app target so their types are available during compilation

## Testing
- not run (Xcode project configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68e5990a9994832aacf6a7e1f17968f3