### PR TITLE
Manual Core Data models without duplicate Identifiable

### DIFF
--- a/Grow/CoreData/ModelEntities.swift
+++ b/Grow/CoreData/ModelEntities.swift
@@ -1,0 +1,135 @@
+import Foundation
+import CoreData
+
+@objc(Badge)
+public class Badge: NSManagedObject {}
+
+extension Badge {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Badge> {
+        return NSFetchRequest<Badge>(entityName: "Badge")
+    }
+
+    @NSManaged public var earnedAt: Date?
+    @NSManaged public var id: UUID?
+    @NSManaged public var key: String?
+}
+
+extension Badge: Identifiable {}
+
+@objc(Debuff)
+public class Debuff: NSManagedObject {}
+
+extension Debuff {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Debuff> {
+        return NSFetchRequest<Debuff>(entityName: "Debuff")
+    }
+
+    @NSManaged public var appliedAt: Date?
+    @NSManaged public var expiresAt: Date?
+    @NSManaged public var expReduction: Double
+    @NSManaged public var id: UUID?
+    @NSManaged public var key: String?
+}
+
+extension Debuff: Identifiable {}
+
+@objc(Habit)
+public class Habit: NSManagedObject {}
+
+extension Habit {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Habit> {
+        return NSFetchRequest<Habit>(entityName: "Habit")
+    }
+
+    @NSManaged public var baseExp: Int32
+    @NSManaged public var bestStreak: Int32
+    @NSManaged public var createdAt: Date?
+    @NSManaged public var currentStreak: Int32
+    @NSManaged public var habitType: String?
+    @NSManaged public var id: UUID?
+    @NSManaged public var isActive: Bool
+    @NSManaged public var lastCompletedDate: Date?
+    @NSManaged public var mode: String?
+    @NSManaged public var name: String?
+    @NSManaged public var scalar: String?
+    @NSManaged public var targetNumber: Double
+    @NSManaged public var logs: HabitLog?
+}
+
+extension Habit: Identifiable {}
+
+@objc(HabitLog)
+public class HabitLog: NSManagedObject {}
+
+extension HabitLog {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<HabitLog> {
+        return NSFetchRequest<HabitLog>(entityName: "HabitLog")
+    }
+
+    @NSManaged public var completed: Bool
+    @NSManaged public var date: Date?
+    @NSManaged public var expGained: Int32
+    @NSManaged public var id: UUID?
+    @NSManaged public var penaltyTriggered: Bool
+    @NSManaged public var valueNumber: Double
+    @NSManaged public var habit: Habit?
+}
+
+extension HabitLog: Identifiable {}
+
+@objc(Skill)
+public class Skill: NSManagedObject {}
+
+extension Skill {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Skill> {
+        return NSFetchRequest<Skill>(entityName: "Skill")
+    }
+
+    @NSManaged public var id: UUID?
+    @NSManaged public var isActive: Bool
+    @NSManaged public var key: String?
+    @NSManaged public var level: Int16
+    @NSManaged public var tier: Int16
+}
+
+extension Skill: Identifiable {}
+
+@objc(UserProfile)
+public class UserProfile: NSManagedObject {}
+
+extension UserProfile {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<UserProfile> {
+        return NSFetchRequest<UserProfile>(entityName: "UserProfile")
+    }
+
+    @NSManaged public var cleansesAvailable: Int16
+    @NSManaged public var createdAt: Date?
+    @NSManaged public var displayName: String?
+    @NSManaged public var expCurrent: Int32
+    @NSManaged public var expToNext: Int32
+    @NSManaged public var id: UUID?
+    @NSManaged public var level: Int32
+    @NSManaged public var permExpMultiplier: Double
+    @NSManaged public var playerClass: String?
+    @NSManaged public var streakShieldAvailable: Bool
+}
+
+extension UserProfile: Identifiable {}
+
+@objc(WeeklyQuest)
+public class WeeklyQuest: NSManagedObject {}
+
+extension WeeklyQuest {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<WeeklyQuest> {
+        return NSFetchRequest<WeeklyQuest>(entityName: "WeeklyQuest")
+    }
+
+    @NSManaged public var completed: Bool
+    @NSManaged public var id: UUID?
+    @NSManaged public var name: String?
+    @NSManaged public var progressCount: Int32
+    @NSManaged public var targetCount: Int32
+    @NSManaged public var weekStartDate: Date?
+}
+
+extension WeeklyQuest: Identifiable {}

--- a/Grow/Grow.xcdatamodeld/Grow.xcdatamodel/contents
+++ b/Grow/Grow.xcdatamodeld/Grow.xcdatamodel/contents
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="24G90" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
-    <entity name="Badge" representedClassName="Badge" syncable="YES" codeGenerationType="class">
+    <entity name="Badge" representedClassName="Badge" syncable="YES" codeGenerationType="manual">
         <attribute name="earnedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="key" optional="YES" attributeType="String"/>
     </entity>
-    <entity name="Debuff" representedClassName="Debuff" syncable="YES" codeGenerationType="class">
+    <entity name="Debuff" representedClassName="Debuff" syncable="YES" codeGenerationType="manual">
         <attribute name="appliedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="expiresAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="expReduction" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="key" optional="YES" attributeType="String"/>
     </entity>
-    <entity name="Habit" representedClassName="Habit" syncable="YES" codeGenerationType="class">
+    <entity name="Habit" representedClassName="Habit" syncable="YES" codeGenerationType="manual">
         <attribute name="baseExp" optional="YES" attributeType="Integer 32" defaultValueString="30" usesScalarValueType="YES"/>
         <attribute name="bestStreak" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -27,7 +27,7 @@
         <attribute name="targetNumber" optional="YES" attributeType="Double" defaultValueString="1" usesScalarValueType="YES"/>
         <relationship name="logs" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="HabitLog" inverseName="habit" inverseEntity="HabitLog"/>
     </entity>
-    <entity name="HabitLog" representedClassName="HabitLog" syncable="YES" codeGenerationType="class">
+    <entity name="HabitLog" representedClassName="HabitLog" syncable="YES" codeGenerationType="manual">
         <attribute name="completed" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="expGained" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
@@ -36,14 +36,14 @@
         <attribute name="valueNumber" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <relationship name="habit" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Habit" inverseName="logs" inverseEntity="Habit"/>
     </entity>
-    <entity name="Skill" representedClassName="Skill" syncable="YES" codeGenerationType="class">
+    <entity name="Skill" representedClassName="Skill" syncable="YES" codeGenerationType="manual">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isActive" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="key" optional="YES" attributeType="String"/>
         <attribute name="level" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="tier" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
-    <entity name="UserProfile" representedClassName="UserProfile" syncable="YES" codeGenerationType="class">
+    <entity name="UserProfile" representedClassName="UserProfile" syncable="YES" codeGenerationType="manual">
         <attribute name="cleansesAvailable" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="displayName" optional="YES" attributeType="String"/>
@@ -55,7 +55,7 @@
         <attribute name="playerClass" optional="YES" attributeType="String"/>
         <attribute name="streakShieldAvailable" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
     </entity>
-    <entity name="WeeklyQuest" representedClassName="WeeklyQuest" syncable="YES" codeGenerationType="class">
+    <entity name="WeeklyQuest" representedClassName="WeeklyQuest" syncable="YES" codeGenerationType="manual">
         <attribute name="completed" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>

--- a/Grow/Models/Models.swift
+++ b/Grow/Models/Models.swift
@@ -113,10 +113,3 @@ struct Achievement: Codable, Identifiable {
     var isUnlocked: Bool { progress >= target }
 }
 
-extension UserProfile: Identifiable {}
-extension Habit: Identifiable {}
-extension HabitLog: Identifiable {}
-extension WeeklyQuest: Identifiable {}
-extension Skill: Identifiable {}
-extension Badge: Identifiable {}
-extension Debuff: Identifiable {}


### PR DESCRIPTION
## Summary
- switch all Core Data entities to manual code generation to stop Xcode from emitting duplicate Identifiable conformances
- add explicit NSManagedObject subclasses and property extensions for each entity, including Identifiable conformance where needed
- remove redundant Identifiable extensions from the shared models file now that conformance lives with the Core Data entities

## Testing
- not run (iOS build tooling unavailable in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e59c2336e4832a8617d7aa71fb9dc1