### PR TITLE
Fix duplicate game support model declarations

### DIFF
--- a/Grow/Managers/GameSupportModels.swift
+++ b/Grow/Managers/GameSupportModels.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import Foundation
+
+enum SkillKey: String, Codable, CaseIterable {
+    case earlyBird = "early_bird"
+    case specialist = "specialist"
+    case ironWill = "iron_will"
+    case nightOwl = "night_owl"
+    case perfectionist = "perfectionist"
+    case resilient = "resilient"
+
+    var name: String {
+        switch self {
+        case .earlyBird: return "Early Bird"
+        case .specialist: return "Specialist"
+        case .ironWill: return "Iron Will"
+        case .nightOwl: return "Night Owl"
+        case .perfectionist: return "Perfectionist"
+        case .resilient: return "Resilient"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .earlyBird: return "+10% EXP before 10am"
+        case .specialist: return "+10% EXP on top 2 habits"
+        case .ironWill: return "-20% penalty 2×/week"
+        case .nightOwl: return "+10% EXP after 8pm"
+        case .perfectionist: return "+15% EXP on perfect days"
+        case .resilient: return "Streak shield recharges faster"
+        }
+    }
+
+    var tier: Int {
+        switch self {
+        case .earlyBird, .specialist, .ironWill:
+            return 1
+        case .nightOwl, .perfectionist, .resilient:
+            return 2
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .earlyBird: return "sunrise.fill"
+        case .specialist: return "star.fill"
+        case .ironWill: return "shield.fill"
+        case .nightOwl: return "moon.stars.fill"
+        case .perfectionist: return "sparkles"
+        case .resilient: return "heart.fill"
+        }
+    }
+}
+
+struct LeaderboardEntry: Codable, Identifiable {
+    var id: String { userId }
+    let userId: String
+    let displayName: String
+    let playerClass: String
+    let level: Int
+    let totalExp: Int
+    let weeklyExp: Int
+    let bestStreak: Int
+    let updatedAt: Date
+    var rank: Int = 0
+}

--- a/Grow/Models/Models.swift
+++ b/Grow/Models/Models.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import CoreData
 import Foundation
 
 enum HabitType: String, Codable, CaseIterable {
@@ -36,70 +35,6 @@ enum PlayerClass: String, Codable, CaseIterable {
     }
 }
 
-enum SkillKey: String, Codable, CaseIterable {
-    case earlyBird = "early_bird"
-    case specialist = "specialist"
-    case ironWill = "iron_will"
-    case nightOwl = "night_owl"
-    case perfectionist = "perfectionist"
-    case resilient = "resilient"
-
-    var name: String {
-        switch self {
-        case .earlyBird: return "Early Bird"
-        case .specialist: return "Specialist"
-        case .ironWill: return "Iron Will"
-        case .nightOwl: return "Night Owl"
-        case .perfectionist: return "Perfectionist"
-        case .resilient: return "Resilient"
-        }
-    }
-
-    var description: String {
-        switch self {
-        case .earlyBird: return "+10% EXP before 10am"
-        case .specialist: return "+10% EXP on top 2 habits"
-        case .ironWill: return "-20% penalty 2×/week"
-        case .nightOwl: return "+10% EXP after 8pm"
-        case .perfectionist: return "+15% EXP on perfect days"
-        case .resilient: return "Streak shield recharges faster"
-        }
-    }
-
-    var tier: Int {
-        switch self {
-        case .earlyBird, .specialist, .ironWill:
-            return 1
-        case .nightOwl, .perfectionist, .resilient:
-            return 2
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .earlyBird: return "sunrise.fill"
-        case .specialist: return "star.fill"
-        case .ironWill: return "shield.fill"
-        case .nightOwl: return "moon.stars.fill"
-        case .perfectionist: return "sparkles"
-        case .resilient: return "heart.fill"
-        }
-    }
-}
-
-struct LeaderboardEntry: Codable, Identifiable {
-    var id: String { userId }
-    let userId: String
-    let displayName: String
-    let playerClass: String
-    let level: Int
-    let totalExp: Int
-    let weeklyExp: Int
-    let bestStreak: Int
-    let updatedAt: Date
-    var rank: Int = 0
-}
-
 struct Achievement: Codable, Identifiable {
     let id: String
     let key: String
@@ -113,10 +48,3 @@ struct Achievement: Codable, Identifiable {
     var isUnlocked: Bool { progress >= target }
 }
 
-extension UserProfile: Identifiable {}
-extension Habit: Identifiable {}
-extension HabitLog: Identifiable {}
-extension WeeklyQuest: Identifiable {}
-extension Skill: Identifiable {}
-extension Badge: Identifiable {}
-extension Debuff: Identifiable {}


### PR DESCRIPTION
## Summary
- move the SkillKey and LeaderboardEntry models into a dedicated GameSupportModels file to avoid duplicate declarations
- remove redundant Identifiable extensions that conflict with Core Data generated code

## Testing
- Not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5b4633618832a8c202a86a90f279c