### PR TITLE
Handle macOS SwiftUI compatibility issues

### DIFF
--- a/Grow/Extensions/Color+Adaptive.swift
+++ b/Grow/Extensions/Color+Adaptive.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+extension Color {
+    static var adaptiveSystemBackground: Color {
+        #if os(iOS)
+        return Color(UIColor.systemBackground)
+        #elseif os(macOS)
+        return Color(NSColor.windowBackgroundColor)
+        #else
+        return Color.white
+        #endif
+    }
+}

--- a/Grow/Views/DashboardView.swift
+++ b/Grow/Views/DashboardView.swift
@@ -116,7 +116,7 @@ struct ProfileHeader: View {
             .padding()
             .background(
                 RoundedRectangle(cornerRadius: 20)
-                    .fill(Color(.systemBackground))
+                    .fill(Color.adaptiveSystemBackground)
                     .shadow(color: .black.opacity(0.1), radius: 10)
             )
             .padding(.horizontal)
@@ -288,7 +288,7 @@ struct HabitCard: View {
         .padding()
         .background(
             RoundedRectangle(cornerRadius: 15)
-                .fill(Color(.systemBackground))
+                .fill(Color.adaptiveSystemBackground)
                 .shadow(color: .black.opacity(0.05), radius: 5)
         )
         .padding(.horizontal)
@@ -327,7 +327,9 @@ struct QuantityInputSheet: View {
                 VStack(spacing: 20) {
                     TextField("0", value: $value, format: .number)
                         .textFieldStyle(.plain)
+#if os(iOS)
                         .keyboardType(.decimalPad)
+#endif
                         .font(.system(size: 60, weight: .bold))
                         .multilineTextAlignment(.center)
                         .frame(height: 80)

--- a/Grow/Views/OnboardingView.swift
+++ b/Grow/Views/OnboardingView.swift
@@ -34,7 +34,11 @@ struct OnboardingView: View {
                 habitsPage.tag(2)
                 questPage.tag(3)
             }
+#if os(iOS)
             .tabViewStyle(.page(indexDisplayMode: .always))
+#else
+            .tabViewStyle(DefaultTabViewStyle())
+#endif
         }
     }
     
@@ -309,7 +313,7 @@ struct HabitCheckbox: View {
                 Spacer()
             }
             .padding()
-            .background(Color(.systemBackground))
+            .background(Color.adaptiveSystemBackground)
             .cornerRadius(12)
         }
     }


### PR DESCRIPTION
## Summary
- replace iOS-only system background colors with a cross-platform adaptive color helper
- guard decimal keypad usage to iOS so quantity input compiles on macOS builds
- fall back to the default TabView style on macOS onboarding screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b8781394832ab292cb0e15b28f56