### PR TITLE
Improve cross-platform SwiftUI compatibility

### DIFF
--- a/Grow/Extensions/Color+Adaptive.swift
+++ b/Grow/Extensions/Color+Adaptive.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+extension Color {
+    static var adaptiveSystemBackground: Color {
+        #if canImport(UIKit)
+        return Color(uiColor: .systemBackground)
+        #elseif canImport(AppKit)
+        return Color(nsColor: .windowBackgroundColor)
+        #else
+        return Color.white
+        #endif
+    }
+}

--- a/Grow/Views/DashboardView.swift
+++ b/Grow/Views/DashboardView.swift
@@ -116,7 +116,7 @@ struct ProfileHeader: View {
             .padding()
             .background(
                 RoundedRectangle(cornerRadius: 20)
-                    .fill(Color(.systemBackground))
+                    .fill(Color.adaptiveSystemBackground)
                     .shadow(color: .black.opacity(0.1), radius: 10)
             )
             .padding(.horizontal)
@@ -288,7 +288,7 @@ struct HabitCard: View {
         .padding()
         .background(
             RoundedRectangle(cornerRadius: 15)
-                .fill(Color(.systemBackground))
+                .fill(Color.adaptiveSystemBackground)
                 .shadow(color: .black.opacity(0.05), radius: 5)
         )
         .padding(.horizontal)
@@ -327,7 +327,7 @@ struct QuantityInputSheet: View {
                 VStack(spacing: 20) {
                     TextField("0", value: $value, format: .number)
                         .textFieldStyle(.plain)
-                        .keyboardType(.decimalPad)
+                        .decimalPadKeyboard()
                         .font(.system(size: 60, weight: .bold))
                         .multilineTextAlignment(.center)
                         .frame(height: 80)
@@ -357,3 +357,17 @@ struct QuantityInputSheet: View {
         }
     }
 }
+
+#if os(iOS)
+private extension View {
+    func decimalPadKeyboard() -> some View {
+        keyboardType(.decimalPad)
+    }
+}
+#else
+private extension View {
+    func decimalPadKeyboard() -> some View {
+        self
+    }
+}
+#endif

--- a/Grow/Views/OnboardingView.swift
+++ b/Grow/Views/OnboardingView.swift
@@ -34,7 +34,11 @@ struct OnboardingView: View {
                 habitsPage.tag(2)
                 questPage.tag(3)
             }
-            .tabViewStyle(.page(indexDisplayMode: .always))
+#if os(iOS)
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))
+#else
+            .tabViewStyle(DefaultTabViewStyle())
+#endif
         }
     }
     
@@ -309,7 +313,7 @@ struct HabitCheckbox: View {
                 Spacer()
             }
             .padding()
-            .background(Color(.systemBackground))
+            .background(Color.adaptiveSystemBackground)
             .cornerRadius(12)
         }
     }


### PR DESCRIPTION
## Summary
- ensure the adaptive system background color helper imports the correct platform frameworks for both iOS and macOS builds
- wrap the decimal keypad modifier in a platform-aware helper so quantity entry compiles on macOS
- continue to use PageTabViewStyle only on iOS while defaulting to the standard tab view on macOS onboarding

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b8781394832ab292cb0e15b28f56