### PR TITLE
Create multi-app side menu experience

### DIFF
--- a/Grow/Views/AppMenu.swift
+++ b/Grow/Views/AppMenu.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+enum AppModule: CaseIterable, Identifiable {
+    case yuka
+    case strava
+    case myFitnessPal
+    case studyBunny
+    case habitTracker
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .yuka: return "Yuka"
+        case .strava: return "Strava"
+        case .myFitnessPal: return "MyFitnessPal"
+        case .studyBunny: return "Study Bunny"
+        case .habitTracker: return "Habit Tracker"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .yuka: return "Scan foods and auto-log nutrition"
+        case .strava: return "Track activities, lifts, and weekly stats"
+        case .myFitnessPal: return "Log meals, weight, and XP rewards"
+        case .studyBunny: return "Stay focused with timed study sessions"
+        case .habitTracker: return "Build routines with streak tracking"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .yuka: return "barcode.viewfinder"
+        case .strava: return "figure.run"
+        case .myFitnessPal: return "fork.knife"
+        case .studyBunny: return "books.vertical"
+        case .habitTracker: return "checkmark.circle"
+        }
+    }
+
+    var accentColor: Color {
+        switch self {
+        case .yuka: return .green
+        case .strava: return .orange
+        case .myFitnessPal: return .blue
+        case .studyBunny: return .purple
+        case .habitTracker: return .mint
+        }
+    }
+}
+
+struct SideMenuView: View {
+    let selection: AppModule
+    let onSelect: (AppModule) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Grow Hub")
+                    .font(.largeTitle.weight(.bold))
+                Text("All of your wellness tools in one place.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(AppModule.allCases) { module in
+                    Button {
+                        onSelect(module)
+                    } label: {
+                        HStack(spacing: 14) {
+                            Image(systemName: module.icon)
+                                .font(.system(size: 18, weight: .semibold))
+                                .frame(width: 36, height: 36)
+                                .foregroundStyle(.white)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                        .fill(
+                                            LinearGradient(
+                                                colors: [module.accentColor.opacity(0.85), module.accentColor],
+                                                startPoint: .topLeading,
+                                                endPoint: .bottomTrailing
+                                            )
+                                        )
+                                )
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(module.title)
+                                    .font(.headline)
+                                Text(module.subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            }
+
+                            Spacer()
+
+                            if module == selection {
+                                Image(systemName: "chevron.right")
+                                    .font(.caption.bold())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .fill(module == selection ? Color.cardBackground.opacity(0.9) : .clear)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Need a break?")
+                    .font(.headline)
+                Text("Switch modules at any time to stay balanced across food, fitness, habits, and focus.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(Color.cardBackground)
+            )
+        }
+        .padding(.vertical, 32)
+        .padding(.horizontal, 20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial)
+        .ignoresSafeArea()
+    }
+}
+
+struct MenuButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "line.3.horizontal")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(.primary)
+                .frame(width: 44, height: 44)
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(Color.cardBackground.opacity(0.92))
+                        .shadow(color: Color.black.opacity(0.1), radius: 10, y: 4)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Grow/Views/HabitTrackerView.swift
+++ b/Grow/Views/HabitTrackerView.swift
@@ -1,0 +1,327 @@
+import SwiftUI
+
+struct HabitTrackerView: View {
+    let onMenuToggle: () -> Void
+
+    @State private var habits: [HabitTrackerItem] = [
+        HabitTrackerItem(
+            name: "Morning mobility",
+            goal: "Stretch for 5 minutes",
+            streak: 3,
+            lastCompletion: Calendar.current.date(byAdding: .day, value: -1, to: Date())
+        ),
+        HabitTrackerItem(name: "Hydration", goal: "Drink 8 glasses of water", streak: 0, lastCompletion: nil)
+    ]
+    @State private var showAddHabit = false
+
+    private var calendar: Calendar { Calendar.current }
+
+    private var completedToday: Int {
+        habits.filter { $0.isCompleted(today: Date(), calendar: calendar) }.count
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    headerCard
+                    habitList
+                    routinesTips
+                }
+                .padding(.vertical, 28)
+                .padding(.horizontal, 20)
+            }
+            .background(Color.screenBackground.ignoresSafeArea())
+            .navigationTitle("Habit Tracker")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    MenuButton(action: onMenuToggle)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showAddHabit = true
+                    } label: {
+                        Label("New Habit", systemImage: "plus.circle.fill")
+                    }
+                }
+            }
+            .sheet(isPresented: $showAddHabit) {
+                AddHabitView { habit in
+                    habits.append(habit)
+                }
+            }
+        }
+    }
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Daily momentum")
+                .font(.headline)
+            Text("Check off small wins every day to build lasting routines and boost your Grow profile.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            HStack(spacing: 16) {
+                habitStat(title: "Habits", value: "\(habits.count)", icon: "list.bullet")
+                habitStat(title: "Completed", value: "\(completedToday)", icon: "checkmark.circle.fill")
+                habitStat(title: "Best streak", value: "\(habits.map(\.streak).max() ?? 0)", icon: "flame.fill")
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var habitList: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Today's habits")
+                .font(.headline)
+
+            if habits.isEmpty {
+                Text("Add your first habit to start building your streaks.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(spacing: 12) {
+                    ForEach(habits.indices, id: \.self) { index in
+                        HabitRow(habit: habits[index], calendar: calendar) { completed in
+                            toggleHabitCompletion(at: index, completed: completed)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var routinesTips: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Consistency ideas")
+                .font(.headline)
+
+            HabitTipRow(icon: "bell", title: "Stack habits", description: "Attach a new routine to one you already do, like stretching after brushing your teeth.")
+            HabitTipRow(icon: "sparkles", title: "Celebrate streaks", description: "Give yourself a reward when you hit a seven-day streak.")
+            HabitTipRow(icon: "person.2.fill", title: "Stay accountable", description: "Share progress with a friend or coach to stay motivated.")
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private func habitStat(title: String, value: String, icon: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(.mint)
+            Text(value)
+                .font(.title3.weight(.bold))
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color.mint.opacity(0.12))
+        )
+    }
+
+    private func toggleHabitCompletion(at index: Int, completed: Bool) {
+        guard habits.indices.contains(index) else { return }
+
+        if completed {
+            habits[index].markCompleted(on: Date(), calendar: calendar)
+        } else {
+            habits[index].resetToday(calendar: calendar)
+        }
+    }
+}
+
+private struct HabitTipRow: View {
+    let icon: String
+    let title: String
+    let description: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(.mint)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct HabitRow: View {
+    @State private var isExpanded = false
+    let habit: HabitTrackerItem
+    let calendar: Calendar
+    let onToggle: (Bool) -> Void
+
+    private var completedToday: Bool {
+        habit.isCompleted(today: Date(), calendar: calendar)
+    }
+
+    private var streakText: String {
+        completedToday ? "Streak: \(habit.streak) days" : "Current streak: \(habit.streak)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(habit.name)
+                        .font(.headline)
+                    Text(habit.goal)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Toggle(isOn: .init(
+                    get: { completedToday },
+                    set: { onToggle($0) }
+                )) {
+                    Text("")
+                }
+                .toggleStyle(SwitchToggleStyle(tint: .mint))
+                .labelsHidden()
+            }
+
+            HStack {
+                Label(streakText, systemImage: "flame")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button {
+                    withAnimation(.spring()) {
+                        isExpanded.toggle()
+                    }
+                } label: {
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.caption.bold())
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if isExpanded {
+                Divider()
+                VStack(alignment: .leading, spacing: 8) {
+                    if let last = habit.lastCompletion {
+                        Text("Last completed: \(formatted(last))")
+                    }
+                    Text("Tip: Block time for this habit in your calendar to make it non-negotiable.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private func formatted(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}
+
+private struct AddHabitView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String = ""
+    @State private var goal: String = ""
+
+    let onSave: (HabitTrackerItem) -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Habit") {
+                    TextField("Name", text: $name)
+                    TextField("Reminder", text: $goal)
+                }
+            }
+            .navigationTitle("New Habit")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let habit = HabitTrackerItem(name: name.isEmpty ? "New Habit" : name, goal: goal.isEmpty ? "Stay consistent" : goal)
+                        onSave(habit)
+                        dismiss()
+                    }
+                    .disabled(name.isEmpty)
+                }
+            }
+        }
+    }
+}
+
+struct HabitTrackerItem: Identifiable {
+    let id = UUID()
+    var name: String
+    var goal: String
+    var streak: Int
+    var lastCompletion: Date?
+
+    init(name: String, goal: String, streak: Int = 0, lastCompletion: Date? = nil) {
+        self.name = name
+        self.goal = goal
+        self.streak = streak
+        self.lastCompletion = lastCompletion
+    }
+
+    func isCompleted(today: Date, calendar: Calendar) -> Bool {
+        guard let lastCompletion else { return false }
+        return calendar.isDate(lastCompletion, inSameDayAs: today)
+    }
+
+    mutating func markCompleted(on date: Date, calendar: Calendar) {
+        if let lastCompletion, calendar.isDate(lastCompletion, inSameDayAs: calendar.date(byAdding: .day, value: -1, to: date) ?? date) {
+            streak += 1
+        } else if !isCompleted(today: date, calendar: calendar) {
+            streak = max(streak, 0) + 1
+        }
+
+        lastCompletion = date
+    }
+
+    mutating func resetToday(calendar: Calendar) {
+        guard let lastCompletion else { return }
+        if calendar.isDateInToday(lastCompletion) {
+            lastCompletion = nil
+            streak = max(streak - 1, 0)
+        }
+    }
+}

--- a/Grow/Views/NutritionView.swift
+++ b/Grow/Views/NutritionView.swift
@@ -4,6 +4,7 @@ struct NutritionView: View {
     @ObservedObject var nutritionManager: NutritionManager
     let profile: UserProfile?
     @ObservedObject var gameManager: GameManager
+    let onMenuToggle: () -> Void
 
     @State private var showAddFood = false
     @State private var showAddWeight = false
@@ -85,6 +86,10 @@ struct NutritionView: View {
             .background(Color.screenBackground.ignoresSafeArea())
             .navigationTitle("Nutrition")
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    MenuButton(action: onMenuToggle)
+                }
+
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button {
                         showScanner = true

--- a/Grow/Views/StravaHubView.swift
+++ b/Grow/Views/StravaHubView.swift
@@ -1,0 +1,359 @@
+import SwiftUI
+
+struct StravaHubView: View {
+    @ObservedObject var gymManager: GymManager
+    @ObservedObject var gameManager: GameManager
+    let profile: UserProfile?
+    let onMenuToggle: () -> Void
+
+    @State private var showLogWorkout = false
+    @State private var showLiftsDashboard = false
+    @State private var selectedWorkout: Workout?
+
+    private var workouts: [Workout] { gymManager.workouts }
+    private var recentWorkouts: [Workout] { Array(workouts.prefix(10)) }
+
+    private var thisWeekWorkouts: [Workout] {
+        guard let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date()) else { return [] }
+        return workouts.filter { workout in
+            guard let date = workout.date else { return false }
+            return date >= weekAgo
+        }
+    }
+
+    private var totalMinutesThisWeek: Int {
+        thisWeekWorkouts.reduce(0) { total, workout in
+            total + Int(workout.duration)
+        }
+    }
+
+    private var totalExperienceThisWeek: Int {
+        gameManager.experienceTimeline
+            .filter { event in
+                event.source == .workout && Calendar.current.isDate(event.timestamp, equalTo: Date(), toGranularity: .weekOfYear)
+            }
+            .reduce(0) { $0 + $1.amount }
+    }
+
+    private var streakCount: Int {
+        let calendar = Calendar.current
+        var streak = 0
+        var date = calendar.startOfDay(for: Date())
+
+        while workouts.contains(where: { workout in
+            guard let workoutDate = workout.date else { return false }
+            return calendar.isDate(workoutDate, inSameDayAs: date)
+        }) {
+            streak += 1
+            guard let previousDay = calendar.date(byAdding: .day, value: -1, to: date) else { break }
+            date = previousDay
+        }
+
+        return streak
+    }
+
+    private var topPersonalRecords: [(exercise: String, value: Double)] {
+        gymManager.personalRecords
+            .sorted { $0.value > $1.value }
+            .prefix(3)
+            .map { ($0.key, $0.value) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    summaryCard
+                    quickActionsCard
+                    activityFeed
+                    liftsPreview
+                }
+                .padding(.vertical, 28)
+                .padding(.horizontal, 20)
+            }
+            .background(Color.screenBackground.ignoresSafeArea())
+            .navigationTitle("Strava")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    MenuButton(action: onMenuToggle)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showLogWorkout = true
+                    } label: {
+                        Label("Log workout", systemImage: "plus.circle.fill")
+                    }
+                }
+            }
+            .sheet(isPresented: $showLogWorkout) {
+                WorkoutDetailSheet(
+                    workoutManager: gymManager,
+                    gameManager: gameManager
+                )
+            }
+            .sheet(isPresented: $showLiftsDashboard) {
+                NavigationStack {
+                    LiftsView(gymManager: gymManager, gameManager: gameManager)
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Done") { showLiftsDashboard = false }
+                            }
+                        }
+                }
+            }
+            .sheet(item: $selectedWorkout) { workout in
+                WorkoutDetailsView(workout: workout)
+            }
+        }
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("This Week")
+                        .font(.title3.weight(.bold))
+                    if let profile {
+                        Text("Level \(profile.level) • \(Int(profile.expCurrent))/\(profile.expToNext) XP")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing) {
+                    Text("\(streakCount) day streak")
+                        .font(.headline)
+                    Text("Keep it going!")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+
+            HStack(spacing: 16) {
+                statPill(title: "Workouts", value: "\(thisWeekWorkouts.count)", icon: "figure.run", tint: .orange)
+                statPill(title: "Minutes", value: "\(totalMinutesThisWeek)", icon: "clock.fill", tint: .blue)
+                statPill(title: "XP Earned", value: "+\(totalExperienceThisWeek)", icon: "sparkles", tint: .purple)
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var quickActionsCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Quick Actions")
+                .font(.headline)
+
+            HStack(spacing: 16) {
+                Button {
+                    showLogWorkout = true
+                } label: {
+                    actionTile(
+                        icon: "figure.strengthtraining.traditional",
+                        title: "Log Activity",
+                        subtitle: "Record cardio or lifts",
+                        tint: .orange
+                    )
+                }
+
+                Button {
+                    showLiftsDashboard = true
+                } label: {
+                    actionTile(
+                        icon: "dumbbell.fill",
+                        title: "Lifts Dashboard",
+                        subtitle: "Review PRs & volume",
+                        tint: .purple
+                    )
+                }
+            }
+
+            if let latest = workouts.first, let date = latest.date {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Last workout")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(latest.title ?? "Workout")
+                        .font(.headline)
+                    Text("\(formattedDate(date)) • \(Int(latest.duration)) min")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var activityFeed: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Activity Feed")
+                    .font(.headline)
+                Spacer()
+                if !recentWorkouts.isEmpty {
+                    Text("Latest \(recentWorkouts.count)")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if recentWorkouts.isEmpty {
+                Text("Log your first workout to see it here.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(recentWorkouts, id: \.objectID) { workout in
+                        Button {
+                            selectedWorkout = workout
+                        } label: {
+                            HStack(spacing: 16) {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(workout.title ?? "Workout")
+                                        .font(.headline)
+                                        .foregroundStyle(.primary)
+                                    Text("\(formattedDate(workout.date ?? Date())) • \(Int(workout.duration)) min")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Spacer()
+
+                                Image(systemName: "chevron.right")
+                                    .font(.caption.bold())
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(14)
+                            .background(
+                                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                    .fill(Color.cardBackground)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var liftsPreview: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Top Lifts")
+                    .font(.headline)
+                Spacer()
+                Button("Open Lifts") { showLiftsDashboard = true }
+                    .font(.footnote.weight(.semibold))
+            }
+
+            if topPersonalRecords.isEmpty {
+                Text("Log strength workouts to build your PR library.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(topPersonalRecords, id: \.exercise) { record in
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(record.exercise)
+                                    .font(.headline)
+                                Text("Best est. 1RM: \(String(format: "%.1f", record.value)) kg")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "flame.fill")
+                                .foregroundStyle(.orange)
+                        }
+                        .padding(14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .fill(Color.cardBackground)
+                        )
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private func statPill(title: String, value: String, icon: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+            Text(value)
+                .font(.title3.weight(.bold))
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(tint.opacity(0.12))
+        )
+    }
+
+    private func actionTile(icon: String, title: String, subtitle: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 48, height: 48)
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [tint.opacity(0.85), tint],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                )
+
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+}

--- a/Grow/Views/StudyTrackerView.swift
+++ b/Grow/Views/StudyTrackerView.swift
@@ -1,0 +1,359 @@
+import SwiftUI
+
+struct StudyTrackerView: View {
+    let onMenuToggle: () -> Void
+
+    @State private var sessions: [StudySession] = []
+    @State private var focusTopic: String = ""
+    @State private var plannedDuration: Int = 25
+    @State private var showAddSession = false
+
+    private var calendar: Calendar { Calendar.current }
+
+    private var todayMinutes: Int {
+        let today = Date()
+        return sessions
+            .filter { calendar.isDate($0.date, inSameDayAs: today) }
+            .reduce(0) { $0 + $1.minutes }
+    }
+
+    private var weekMinutes: Int {
+        guard let weekStart = calendar.date(byAdding: .day, value: -6, to: calendar.startOfDay(for: Date())) else { return 0 }
+        return sessions
+            .filter { session in
+                session.date >= weekStart
+            }
+            .reduce(0) { $0 + $1.minutes }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    summaryCard
+                    focusPlannerCard
+                    sessionHistory
+                    tipsCard
+                }
+                .padding(.vertical, 28)
+                .padding(.horizontal, 20)
+            }
+            .background(Color.screenBackground.ignoresSafeArea())
+            .navigationTitle("Study Bunny")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    MenuButton(action: onMenuToggle)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showAddSession = true
+                    } label: {
+                        Label("Log Session", systemImage: "plus.circle.fill")
+                    }
+                }
+            }
+            .sheet(isPresented: $showAddSession) {
+                AddStudySessionView { newSession in
+                    sessions.insert(newSession, at: 0)
+                }
+            }
+        }
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Focused progress")
+                .font(.headline)
+            Text("Stay consistent with your study streak and reward yourself when you hit your targets.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            HStack(spacing: 16) {
+                statBlock(title: "Today", value: "\(todayMinutes) min", icon: "sun.max.fill", tint: .orange)
+                statBlock(title: "This Week", value: "\(weekMinutes) min", icon: "calendar", tint: .blue)
+                statBlock(title: "Sessions", value: "\(sessions.count)", icon: "book", tint: .purple)
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var focusPlannerCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Plan a focus sprint")
+                .font(.headline)
+
+            TextField("Topic or task", text: $focusTopic)
+                .textFieldStyle(.roundedBorder)
+
+            Stepper(value: $plannedDuration, in: 10...90, step: 5) {
+                Text("Duration: \(plannedDuration) minutes")
+            }
+
+            Button {
+                let session = StudySession(
+                    topic: focusTopic.isEmpty ? "Focus Session" : focusTopic,
+                    minutes: plannedDuration,
+                    date: Date(),
+                    mood: .motivated
+                )
+                sessions.insert(session, at: 0)
+                focusTopic = ""
+                plannedDuration = 25
+            } label: {
+                Text("Start & Log Session")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(
+                                LinearGradient(
+                                    colors: [Color.purple.opacity(0.85), .purple],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                )
+                            )
+                    )
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var sessionHistory: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Session History")
+                .font(.headline)
+
+            if sessions.isEmpty {
+                Text("Log a study sprint to start building your momentum.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(sessions) { session in
+                        StudySessionRow(session: session) { completed in
+                            if let index = sessions.firstIndex(where: { $0.id == session.id }) {
+                                sessions[index].mood = completed
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var tipsCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Productivity tips")
+                .font(.headline)
+            VStack(alignment: .leading, spacing: 8) {
+                TipRow(icon: "timer", title: "Use the Pomodoro technique", description: "Work for 25 minutes, rest for 5, and repeat to maintain focus.")
+                TipRow(icon: "moon.stars.fill", title: "End with reflection", description: "Write a short recap of what you learned to improve retention.")
+                TipRow(icon: "sparkles", title: "Reward progress", description: "After three sessions in a day, celebrate with a break or small treat.")
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private func statBlock(title: String, value: String, icon: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+            Text(value)
+                .font(.title3.weight(.bold))
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(tint.opacity(0.12))
+        )
+    }
+}
+
+private struct TipRow: View {
+    let icon: String
+    let title: String
+    let description: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundStyle(.purple)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(description)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct StudySessionRow: View {
+    let session: StudySession
+    let onMoodChange: (StudyMood) -> Void
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: session.date)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(session.topic)
+                        .font(.headline)
+                    Text(formattedDate)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Text("\(session.minutes) min")
+                    .font(.subheadline.weight(.semibold))
+            }
+
+            HStack {
+                ForEach(StudyMood.allCases) { mood in
+                    Button {
+                        onMoodChange(mood)
+                    } label: {
+                        Image(systemName: mood.icon)
+                            .font(.subheadline)
+                            .foregroundStyle(session.mood == mood ? .white : .secondary)
+                            .frame(width: 36, height: 32)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                    .fill(session.mood == mood ? Color.purple : Color.cardBackground)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+}
+
+private struct AddStudySessionView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var topic: String = ""
+    @State private var minutes: Int = 30
+    @State private var selectedMood: StudyMood = .productive
+
+    let onSave: (StudySession) -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Details") {
+                    TextField("Topic", text: $topic)
+
+                    Stepper(value: $minutes, in: 10...240, step: 5) {
+                        Text("Duration: \(minutes) minutes")
+                    }
+                }
+
+                Section("How did it feel?") {
+                    Picker("Mood", selection: $selectedMood) {
+                        ForEach(StudyMood.allCases) { mood in
+                            Label(mood.title, systemImage: mood.icon)
+                                .tag(mood)
+                        }
+                    }
+                    .pickerStyle(.inline)
+                }
+            }
+            .navigationTitle("Log Study Session")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let session = StudySession(
+                            topic: topic.isEmpty ? "Study Session" : topic,
+                            minutes: minutes,
+                            date: Date(),
+                            mood: selectedMood
+                        )
+                        onSave(session)
+                        dismiss()
+                    }
+                    .disabled(topic.isEmpty && minutes == 0)
+                }
+            }
+        }
+    }
+}
+
+struct StudySession: Identifiable {
+    let id = UUID()
+    var topic: String
+    var minutes: Int
+    var date: Date
+    var mood: StudyMood
+}
+
+enum StudyMood: String, CaseIterable, Identifiable {
+    case productive
+    case motivated
+    case distracted
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .productive: return "Productive"
+        case .motivated: return "Motivated"
+        case .distracted: return "Distracted"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .productive: return "checkmark.seal.fill"
+        case .motivated: return "bolt.heart"
+        case .distracted: return "zzz"
+        }
+    }
+}

--- a/Grow/Views/YukaScannerView.swift
+++ b/Grow/Views/YukaScannerView.swift
@@ -1,0 +1,326 @@
+import SwiftUI
+
+struct YukaScannerView: View {
+    @ObservedObject var nutritionManager: NutritionManager
+    @ObservedObject var gameManager: GameManager
+    let onMenuToggle: () -> Void
+
+    @State private var scannedCode: String?
+    @State private var label: String = ""
+    @State private var kcal: String = ""
+    @State private var protein: String = ""
+    @State private var carbs: String = ""
+    @State private var fat: String = ""
+    @State private var meal: String = "Lunch"
+    @State private var showingHistory = false
+    @State private var showingConfirmation = false
+
+    private var estimatedXP: Int {
+        nutritionManager.calculateExpForFood(
+            kcal: Int(kcal) ?? 0,
+            protein: Int(protein) ?? 0,
+            carbs: Int(carbs) ?? 0,
+            fat: Int(fat) ?? 0
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    headerCard
+
+                    scannerCard
+
+                    if let scannedCode {
+                        entryForm(for: scannedCode)
+                    } else {
+                        placeholderCard
+                    }
+
+                    recentHistory
+                }
+                .padding(.vertical, 28)
+                .padding(.horizontal, 20)
+            }
+            .background(Color.screenBackground.ignoresSafeArea())
+            .navigationTitle("Yuka")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    MenuButton(action: onMenuToggle)
+                }
+
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showingHistory = true
+                    } label: {
+                        Label("History", systemImage: "clock.arrow.circlepath")
+                    }
+                    .disabled(nutritionManager.recentFoods.isEmpty)
+                }
+            }
+            .sheet(isPresented: $showingHistory) {
+                NavigationStack {
+                    List(nutritionManager.recentFoods, id: \.objectID) { food in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(food.label ?? "Unnamed Item")
+                                .font(.headline)
+                            Text("\(food.kcal) kcal • P: \(food.protein)g • C: \(food.carbs)g • F: \(food.fat)g")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    .navigationTitle("Recent Scans")
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") { showingHistory = false }
+                        }
+                    }
+                }
+            }
+            .alert("Log item?", isPresented: $showingConfirmation) {
+                Button("Log to diary", role: .none) {
+                    logFoodEntry()
+                }
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                Text("Add \(label.isEmpty ? "this item" : label) to your nutrition diary?")
+            }
+        }
+    }
+
+    private func logFoodEntry() {
+        guard !label.isEmpty, let calories = Int(kcal) else { return }
+
+        nutritionManager.logFood(
+            label: label,
+            kcal: calories,
+            protein: Int(protein) ?? 0,
+            carbs: Int(carbs) ?? 0,
+            fat: Int(fat) ?? 0,
+            meal: meal,
+            gameManager: gameManager,
+            source: .barcode
+        )
+
+        resetForm()
+    }
+
+    private func resetForm() {
+        scannedCode = nil
+        label = ""
+        kcal = ""
+        protein = ""
+        carbs = ""
+        fat = ""
+        meal = "Lunch"
+    }
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Instant nutrition insights", systemImage: "sparkles")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.green)
+
+            Text("Scan a barcode to pre-fill nutrition details and award XP when you log meals.")
+                .font(.body)
+
+            Divider()
+
+            HStack {
+                VStack(alignment: .leading) {
+                    Text("Today's Logged Meals")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("\(nutritionManager.todayFoodLogs.count)")
+                        .font(.title2.weight(.bold))
+                }
+
+                Spacer()
+
+                VStack(alignment: .leading) {
+                    Text("Calories")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("\(nutritionManager.todayTotals.kcal)")
+                        .font(.title2.weight(.bold))
+                }
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var scannerCard: some View {
+        VStack(spacing: 16) {
+            BarcodeScannerView { code in
+                scannedCode = code
+                label = label.isEmpty ? "Item \(code.suffix(4))" : label
+            }
+            .frame(height: 220)
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+
+            HStack(spacing: 12) {
+                Image(systemName: "barcode")
+                Text("Align the barcode inside the frame. We'll auto-fill everything we can.")
+                    .font(.footnote)
+            }
+            .foregroundStyle(.secondary)
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private func entryForm(for code: String) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Scan Result")
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Barcode: \(code)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                TextField("Label", text: $label)
+                    .textFieldStyle(.roundedBorder)
+
+                Picker("Meal", selection: $meal) {
+                    ForEach(["Breakfast", "Lunch", "Dinner", "Snack"], id: \.self) { value in
+                        Text(value).tag(value)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 16) {
+                GridRow {
+                    nutrientField(title: "Calories", value: $kcal, suffix: "kcal")
+                    nutrientField(title: "Protein", value: $protein, suffix: "g")
+                }
+
+                GridRow {
+                    nutrientField(title: "Carbs", value: $carbs, suffix: "g")
+                    nutrientField(title: "Fat", value: $fat, suffix: "g")
+                }
+            }
+
+            Label("Estimated +\(estimatedXP) XP", systemImage: "sparkles")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.green)
+
+            Button {
+                showingConfirmation = true
+            } label: {
+                Text("Log to MyFitnessPal")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(
+                                LinearGradient(
+                                    colors: [Color.green.opacity(0.85), .green],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                )
+                            )
+                    )
+            }
+            .disabled(label.isEmpty || kcal.isEmpty)
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var placeholderCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("No scan yet")
+                .font(.headline)
+            Text("Point your camera at a barcode to start tracking. We'll remember your last scans for quick logging.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private var recentHistory: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Recent Logs")
+                    .font(.headline)
+                Spacer()
+                Button("See all") { showingHistory = true }
+                    .font(.footnote.weight(.semibold))
+                    .disabled(nutritionManager.recentFoods.isEmpty)
+            }
+
+            if nutritionManager.recentFoods.isEmpty {
+                Text("Your most recent scans will appear here for quick re-logging.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(nutritionManager.recentFoods.prefix(3), id: \.objectID) { food in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(food.label ?? "Unnamed Item")
+                                .font(.headline)
+                            Text("\(food.kcal) kcal • Protein \(food.protein)g")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .fill(Color.screenBackground)
+                        )
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(Color.cardBackground)
+        )
+    }
+
+    private func nutrientField(title: String, value: Binding<String>, suffix: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack {
+                TextField("0", text: value)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(.plain)
+                Text(suffix)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color.screenBackground)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the old tab bar with a collapsible side menu that swaps between Yuka, Strava, MyFitnessPal, Study Bunny, and Habit Tracker modules
- add dedicated SwiftUI screens for barcode scanning, activity insights, study session logging, and habit tracking inside the new hub
- update existing nutrition tooling to integrate with the shared menu control

## Testing
- not run (iOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e68f4df588832a9fa2c98e52f6cc9b